### PR TITLE
Fix composer package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install the plugin, follow these instructions.
 
 2. Then tell Composer to load the plugin:
 
-        composer require craftcms/store-hours
+        composer require craftcms/simple-text
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Simple Text.
 


### PR DESCRIPTION
Just fixing a small mistake in the README file where `composer require craftcms/store-hours` should be `composer require craftcms/simple-text`.